### PR TITLE
~ retract apidoc app module exceptions

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -30,7 +30,7 @@ release = '1.0.0'
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'sphinx.ext.autodoc',
+    #'sphinx.ext.autodoc',
     'sphinx.ext.napoleon',
     'sphinx.ext.viewcode',        # source source link next to docs
     'sphinx.ext.githubpages',     # gh-pages needs a .nojekyll file

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -43,13 +43,6 @@ The code of the project is on Github: https://github.com/meta00/vital_sqi
    _examples/others/index
 
 
-.. toctree::
-   :maxdepth: 2
-   :caption: API
-   :hidden:
-
-   _apidoc/modules
-
 Indices and tables
 ==================
 

--- a/examples/others/plot_read_signal.py
+++ b/examples/others/plot_read_signal.py
@@ -304,9 +304,7 @@ plt.tight_layout()
 plt.show()
 
 
-#################################################################
-# Useful comments and data
-# ------------------------
+
 #
 #.. warning:: Should we use TimeInterval indexes for windows?
 #


### PR DESCRIPTION
There is an issue with the app module that probably raises an error in readthedocs. Although it works locally because it just skips the errors, it is very likely that readthedocs is just stopping if an error is raised. Please double check in your readthedocs account the last compilation that failed and send me the info if you can.

Identified errors:
1. Libraries in app missing: dash, psftp, dash_auth, boto3 (include in readme)
2. utilities is imported with local path . and try: except (please fix)

Thank you!

![works](https://user-images.githubusercontent.com/1579887/119029095-2022f580-b9a0-11eb-87b5-f0b9539aaded.png)
