### PR TITLE
Pinning numba to 0.56.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 librosa>=0.9.2
+numba>=0.56.0
 heartpy>=1.2.6
 hrv-analysis>=1.0.3
 matplotlib==3.3.4

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
     maintainer_email = 'haihb@oucru.org, khoaldv@oucru.org',
     py_modules = ['common', 'data', 'preprocess', 'sqi'],
     install_requires = ['librosa>=0.9.2',
+                        'numba>=0.56.0',
                         'heartpy>=1.2.6',
                         'pmdarima>=1.8.0',
                         'hrv-analysis>=1.0.3',


### PR DESCRIPTION
Hi, 

I don't know If you accept contributions, but in case of a positive response, I managed to solve the issue by pinning the version of numba to 0.56.0.


The tests passes on my end.

